### PR TITLE
feat: make helpdesk email dynamic based on company

### DIFF
--- a/mfi_customization/hooks.py
+++ b/mfi_customization/hooks.py
@@ -164,6 +164,9 @@ doc_events = {
     },
     "Machine Reading":{
         "after_save":"mfi_customization.utils.machine_reading.repetitive_call"
+    },
+    "Company":{
+        "validate": "mfi_customization.mfi.doctype.company.validate_support_email"
     }
     # "Material Request":{
     #     "validate":"mfi_customization.mfi.doctype.material_request.validate",

--- a/mfi_customization/mfi/doctype/company.py
+++ b/mfi_customization/mfi/doctype/company.py
@@ -1,0 +1,7 @@
+from frappe.utils import validate_email_address
+
+
+
+
+def validate_support_email(doc, method):
+    validate_email_address(doc.support_email, True)

--- a/mfi_customization/mfi/doctype/issue.py
+++ b/mfi_customization/mfi/doctype/issue.py
@@ -325,6 +325,7 @@ def after_insert(doc,method):
 	"""
 	if doc.type_of_call == "Service Request" or doc.type_of_call == "Toner":
 		client_emails = (get_customer_emails(doc.project))
+		helpdesk_email = frappe.db.get_value("Company", doc.company, "support_email")
 		subject = f"""Ticket created for Issue"""
 		helpdesk_body = f"""Issue ticket number {doc.name} has been
 							created by {doc.customer}"""
@@ -340,6 +341,6 @@ def after_insert(doc,method):
 			recipients=client_emails,
 			send_email=True, sender="erp@groupmfi.com")
 		make(subject = subject,content=helpdesk_body,
-			recipients="helpdesk.kenya@groupmfi.com",
+			recipients=helpdesk_email,
 			send_email=True, sender="erp@groupmfi.com")
 		frappe.msgprint("Issue ticket creation email has been sent")

--- a/mfi_customization/mfi/doctype/material_request.py
+++ b/mfi_customization/mfi/doctype/material_request.py
@@ -529,7 +529,8 @@ def notify_client_about_material_requested(doc, method):
 
             # notify helpdesk
             email_body = f"""Kindly note that Material Request for ticket number {issue} is awaiting your approval"""
-            recipients="helpdesk.kenya@groupmfi.com"
+            recipients = frappe.db.get_value("Company", doc.company, "support_email")
+
             make(subject = subject, content=email_body, recipients=recipients,
                     send_email=True, sender="erp@groupmfi.com")
 
@@ -542,11 +543,11 @@ def notify_helpdesk_about_material_approval(doc, method):
             # notify helpdesk
             subject = f"""Material request approved for ticket {issue}"""
             email_body = f"""Kindly note that material request for ticket number {issue} has been approved."""
-            recipients="helpdesk.kenya@groupmfi.com"
+            recipients = frappe.db.get_value("Company", doc.company, "support_email")
             make(subject = subject, content=email_body, recipients=recipients,
                     send_email=True, sender="erp@groupmfi.com")
 
-            # notify helpdesk
+            # notify client
             email_body = f"""Task Ticket number {issue} has been dispatched, kindly expect it any time soon."""
             recipients = get_customer_emails(doc.project)
             make(subject = subject, content=email_body, recipients=recipients,

--- a/mfi_customization/mfi/doctype/task.py
+++ b/mfi_customization/mfi/doctype/task.py
@@ -69,7 +69,7 @@ def send_task_completion_email(doc):
 
 		# send email notification to helpdesk
 		helpdesk_email_body = f"""Task ticket number {doc.name} has been successfully completed."""
-		recipients="helpdesk.kenya@groupmfi.com"
+		recipients = frappe.db.get_value("Company", doc.company, "support_email")
 		make(subject = subject, content=helpdesk_email_body, recipients=recipients,
 				send_email=True, sender="erp@groupmfi.com")
 
@@ -118,7 +118,7 @@ def send_task_assignment_email(task):
 
 		# send email to helpdesk
 		body = f"""Ticket no. {task.issue} has been assigned to our Engineer {task.technician_name}"""
-		recipients="helpdesk.kenya@groupmfi.com"
+		recipients = frappe.db.get_value("Company", task.company, "support_email")
 		make(subject = subject,content=body,recipients=recipients,
 			send_email=True, sender="erp@groupmfi.com")
 


### PR DESCRIPTION
**Changes:**
 - Make helpdesk email dynamic with `support_email` field of Company doctype for email notifications.
 - Properly validate `support_email` field