### PR TITLE
feat: send notification to toner support email when type_of_call is toner

### DIFF
--- a/mfi_customization/mfi/doctype/issue.py
+++ b/mfi_customization/mfi/doctype/issue.py
@@ -405,6 +405,8 @@ def send_call_resolved_email(issue):
 			helpdesk_email = frappe.db.get_value("Company", issue.company, "support_email")
 			client_emails = get_customer_emails(issue.project)
 			email_body = f"Issue ticket number {issue.name} has been resolved on call"
+			if issue.type_of_call == "Toner":
+				helpdesk_email = frappe.db.get_value("Company", issue.company, "toner_support_email")
 
 			make(subject = subject,content=email_body,
 				recipients=client_emails,
@@ -419,6 +421,8 @@ def send_issue_closed_email(issue):
 	if status != "Closed" and issue.status == "Closed":
 		subject = f"Issue {issue.name} closed"
 		helpdesk_email = frappe.db.get_value("Company", issue.company, "support_email")
+		if issue.type_of_call == "Toner":
+			helpdesk_email = frappe.db.get_value("Company", issue.company, "toner_support_email")
 		client_emails = get_customer_emails(issue.project)
 		email_body = f"Issue ticket number {issue.name} has been closed"
 

--- a/mfi_customization/mfi/doctype/material_request.py
+++ b/mfi_customization/mfi/doctype/material_request.py
@@ -543,7 +543,10 @@ def notify_client_about_material_requested(doc, method):
 			# notify helpdesk
 			email_body = f"""Kindly note that Material Request for ticket number {issue} is awaiting your approval"""
 			recipients = frappe.db.get_value("Company", doc.company, "support_email")
+			type_of_call = frappe.db.get_value("Task", doc.task, 'type_of_call')
 
+			if type_of_call == "Toner":
+				recipients = frappe.db.get_value("Company", doc.company, "toner_support_email")
 			make(subject = subject, content=email_body, recipients=recipients,
 					send_email=True, sender="erp@groupmfi.com")
 
@@ -557,6 +560,9 @@ def notify_helpdesk_about_material_approval(doc, method):
 			subject = f"""Material request approved for ticket {issue}"""
 			email_body = f"""Kindly note that material request for ticket number {issue} has been approved."""
 			recipients = frappe.db.get_value("Company", doc.company, "support_email")
+			type_of_call = frappe.db.get_value("Task", doc.task, 'type_of_call')
+			if type_of_call == "Toner":
+				recipients = frappe.db.get_value("Company", doc.company, "toner_support_email")
 			make(subject = subject, content=email_body, recipients=recipients,
 					send_email=True, sender="erp@groupmfi.com")
 

--- a/mfi_customization/mfi/doctype/task.py
+++ b/mfi_customization/mfi/doctype/task.py
@@ -72,6 +72,8 @@ def send_task_completion_email(doc):
 		# send email notification to helpdesk
 		helpdesk_email_body = f"""Task ticket number {doc.name} has been successfully completed."""
 		recipients = frappe.db.get_value("Company", doc.company, "support_email")
+		if doc.type_of_call == "Toner":
+			recipients = frappe.db.get_value("Company", doc.company, "toner_support_email")
 		make(subject = subject, content=helpdesk_email_body, recipients=recipients,
 				send_email=True, sender="erp@groupmfi.com")
 
@@ -93,6 +95,9 @@ def send_task_escalation_email(doc):
 			helpdesk_email_body = f"""Task ticket number {doc.name} has been
 								Escalated By {doc.technician_name} for Follow Up."""
 			recipients = frappe.db.get_value("Company", doc.company, "support_email")
+			if doc.type_of_call == "Toner":
+				recipients = frappe.db.get_value("Company", doc.company, "toner_support_email")
+
 			make(subject = subject, content=helpdesk_email_body, recipients=recipients,
 					send_email=True, sender="erp@groupmfi.com")
 
@@ -180,7 +185,7 @@ def on_change(doc,method):
 			elif doc.status=="Working" and doc.attended_date_time:
 				issue.first_responded_on=doc.attended_date_time
 		issue.save()
-	escalation_section(doc)	
+	escalation_section(doc)
 def after_delete(doc,method):
 	for t in frappe.get_all('Asset Repair',filters={'task':doc.name}):
 		frappe.delete_doc('Asset Repair',t.name)
@@ -451,7 +456,7 @@ def set_reading_from_task_to_issue(doc):
 	if doc.get("serial_no"):
 		issue_doc.serial_no = doc.get("serial_no")
 	issue_doc.save()
-	
+
 def validate_reading(doc):
     user_roles= frappe.get_roles(frappe.session.user)
     curr = []
@@ -468,7 +473,7 @@ def validate_reading(doc):
                 lst.total=( int(lst.get('reading') or 0)  + int(lst.get('reading_2') or 0))
                 last.append(lst.total)
                 last_date.append(lst.date)
-		
+
     if len(curr)>0 and len(last)>0:
         print(f'\n\n\n\n\n122{curr},{last}\n\n\n\n\n')
         if doc.issue_type != 'Error message':


### PR DESCRIPTION
**Changes:**

In case of type_of_call as "Toner" - Send email notification to toner helpdesk email set on company wherever it is currently sending to support email of company.